### PR TITLE
Add resopnder delegating to a service callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,27 @@
 9. Talk to the Bot:
    
    ```
-   [12:33:31] <user1> test_bot help
-   [12:33:31] <test_bot> test_bot help - Displays all of the help commands that test_bot knows about.
+   <user1> test_bot help
+   <test_bot> test_bot help - Displays all of the help commands that test_bot knows about.
    test_bot help <query> - Displays all help commands that match <query>.
    test_bot: ping - Responds with 'pong'
-   [12:33:35] <user1> test_bot ping
-   [12:33:35] <test_bot> user1: pong
+   test_bot: actions - Lists available actions provided by this bot
+   test_bot: action <action_id> - Performs an action provided by this bot
+   <user1> test_bot actions
+   <test_bot> user1: Here are the actions you can perform:
+   Action id: action1	Desription: desc1
+   Action id: action2	Desription: desc2
+   Key in `test_bot action <action_id>` to perform the action.
+   <user1> test_bot action action1
+   <test_bot> user1: running action
    ```
    
+   The `actions` and `action ID` commands are provided by the `Bot.Service.Responder`
+   which delegates to a service through its callback:
+   
+   ```elixir
+   config :bot, Bot.Service,
+   callback: Bot.Service.Mock
+   ```
    
 

--- a/README.md
+++ b/README.md
@@ -74,4 +74,13 @@
    callback: Bot.Service.Mock
    ```
    
+## Creating a Service
 
+To implement a service one has to create an umbrella application in the `apps` and implement
+the `Bot.Service` behaviour. Then the module fulfilling that behaviour has to be pointed to
+in the configuration:
+
+```elixir
+config :bot, Bot.Service,
+  callback: MyService.API
+```

--- a/apps/bot/config/config.exs
+++ b/apps/bot/config/config.exs
@@ -6,8 +6,15 @@ config :bot, Bot.Robot,
   aka: "/",
   responders: [
     {Hedwig.Responders.Help, []},
-    {Hedwig.Responders.Ping, []}
+    {Hedwig.Responders.Ping, []},
+    {Bot.Service.Responder, []}
   ],
   jid: "test_bot@lambdadays.org",
   password: "test_bot",
   rooms: [{"test_room@muc.lambdadays.org", []}]
+
+config :bot, Bot.Service,
+  callback: Bot.Service.Mock
+
+import_config "#{Mix.env}.exs"
+

--- a/apps/bot/config/dev.exs
+++ b/apps/bot/config/dev.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :logger,
+  level: :debug

--- a/apps/bot/config/test.exs
+++ b/apps/bot/config/test.exs
@@ -1,0 +1,7 @@
+use Mix.Config
+
+config :logger,
+  # This is required for tests to run properly as the %Hedwig.Message{}
+  # struct doesn't contain the %Hedwig.User{} as a value in the user
+  # field.
+  compile_time_purge_level: :error

--- a/apps/bot/lib/bot.ex
+++ b/apps/bot/lib/bot.ex
@@ -1,18 +1,6 @@
-defmodule PhotoChatbot do
+defmodule Bot do
   @moduledoc """
-  Documentation for PhotoChatbot.
+  Documentation for Bot.
   """
 
-  @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> PhotoChatbot.hello
-      :world
-
-  """
-  def hello do
-    :world
-  end
 end

--- a/apps/bot/lib/bot/service.ex
+++ b/apps/bot/lib/bot/service.ex
@@ -1,0 +1,15 @@
+defmodule Bot.Service do
+  @doc "Defines a behaviour for the Service callback module"
+
+  @type action_id :: String.t
+  @type action_description :: String.t
+  @type action_result :: String.t
+  @type action :: {action_id, action_description}
+
+  @doc "Returns a list of actions provided by the service"
+  @callback actions() :: [action]
+
+  @doc "Runs an action"
+  @callback run_action(action_id) :: {:ok | :error, action_result}
+
+end

--- a/apps/bot/lib/bot/service/mock.ex
+++ b/apps/bot/lib/bot/service/mock.ex
@@ -1,0 +1,16 @@
+defmodule Bot.Service.Mock do
+
+  @type action_id :: String.t
+  @type action_description :: String.t
+  @type action_result :: String.t
+  @type action :: {action_id, action_description}
+
+  @spec actions() :: [action]
+  def actions(), do: [{"action1", "desc1"}, {"action2", "desc2"}]
+
+  @spec run_action(action) :: {:ok | :error, action_result}
+  def run_action("action1"), do: {:ok, "running action1"}
+  def run_action("action2"), do: {:ok, "running action2"}
+  def run_action(_), do: {:error, "unknown_action"}
+
+end

--- a/apps/bot/lib/bot/service/mock.ex
+++ b/apps/bot/lib/bot/service/mock.ex
@@ -1,14 +1,8 @@
 defmodule Bot.Service.Mock do
+  @behaviour Bot.Service
 
-  @type action_id :: String.t
-  @type action_description :: String.t
-  @type action_result :: String.t
-  @type action :: {action_id, action_description}
-
-  @spec actions() :: [action]
   def actions(), do: [{"action1", "desc1"}, {"action2", "desc2"}]
 
-  @spec run_action(action) :: {:ok | :error, action_result}
   def run_action("action1"), do: {:ok, "running action1"}
   def run_action("action2"), do: {:ok, "running action2"}
   def run_action(_), do: {:error, "unknown_action"}

--- a/apps/bot/lib/bot/service/responder.ex
+++ b/apps/bot/lib/bot/service/responder.ex
@@ -1,0 +1,60 @@
+defmodule Bot.Service.Responder do
+  @moduledoc """
+  This is the Hedwig responder that discovers actions available in
+  the configured service.
+  """
+
+  use Hedwig.Responder
+  require Logger
+
+  @service Application.get_env(:bot, Bot.Service)[:callback]
+  @bot_name Application.get_env(:bot, Bot.Robot)[:name]
+
+  # API
+
+  @usage """
+  hedwig: actions - Lists available actions provided by this bot
+  """
+  respond ~r/actions$/i, %Hedwig.Message{user: u} = msg do
+    Logger.debug "Responding to /actions requested by #{u.name}"
+    reply msg, on_actions()
+  end
+
+  @usage """
+  hedwig: action <action_id> - Performs an action provided by this bot
+  """
+  respond ~r/action (?<action_id>\w+)$/, msg do
+    action_id = msg.matches["action_id"]
+    Logger.debug "Performing /action #{action_id} requested by #{msg.user.name}"
+    reply msg, on_perform_action(action_id)
+  end
+
+  @doc false
+  def format_action({action_id, action_desc}) do
+    "Action id: #{action_id}\tDesription: #{action_desc}"
+  end
+
+  # Internal functions
+
+  defp on_actions() do
+    """
+    Here are the actions you can perform:
+    #{actions()}
+    Key in `#{@bot_name} action <action_id>` to perform the action.
+    """
+  end
+
+  defp actions() do
+    @service.actions()
+    |> Enum.map(&format_action/1)
+    |> Enum.join("\n")
+  end
+
+  defp on_perform_action(action_id) do
+    case @service.run_action(action_id) do
+      {:ok, response} -> response
+      {:error, error} -> "failed to run action #{action_id}: #{error}"
+    end
+  end
+
+end

--- a/apps/bot/test/bot/service/responder_test.exs
+++ b/apps/bot/test/bot/service/responder_test.exs
@@ -1,0 +1,61 @@
+defmodule Bot.Service.ResponderTest do
+  use Hedwig.RobotCase
+  alias Bot.Service.Responder
+  
+  @responders [{Responder, []}]
+  @service Application.get_env(:bot, Bot.Service)[:callback]
+
+  # Tests
+
+  @tag start_robot: true, name: "test_bot", responders: @responders
+  test "list actions on /actions", %{adapter: adapter, msg: msg} do
+    send_to_bot(adapter, msg, "test_bot actions")
+
+    received = receive_from_bot()
+    for a <- @service.actions() do
+      assert String.contains?(received, Responder.format_action(a))
+    end
+  end
+
+  @tag start_robot: true, name: "test_bot", responders: @responders
+  test "run an action on /action ID", %{adapter: adapter, msg: msg} do
+    action_id = random_action_id()
+
+    send_to_bot(adapter, msg, "test_bot action #{action_id}")
+
+    received = receive_from_bot()
+    assert String.contains?(received, "running #{action_id}")
+  end
+
+  @tag start_robot: true, name: "test_bot", responders: @responders
+  test "send error on /action INVALID_ID",
+    %{adapter: adapter, msg: msg} do
+    action_id = invalid_action_id()
+    
+    send_to_bot(adapter, msg, "test_bot action #{action_id}")
+    
+    received = receive_from_bot()
+    assert String.contains?(received,
+      "failed to run action #{action_id}")
+  end
+
+  # Internal functions
+
+  defp send_to_bot(adapter, msg, text) do
+    send adapter, {:message, %{msg | text: text}}
+  end
+
+  defp receive_from_bot() do
+    assert_receive {:message, %{text: text}}, 1_000
+    text
+  end
+
+  defp random_action_id() do
+    [{action_id, _}] = Enum.take_random(@service.actions(), 1)
+    action_id
+  end
+
+  defp invalid_action_id(), do: random_action_id() |> String.reverse()
+  
+
+end

--- a/apps/bot/test/bot_test.exs
+++ b/apps/bot/test/bot_test.exs
@@ -1,8 +1,0 @@
-defmodule BotTest do
-  use ExUnit.Case
-  doctest Bot
-
-  test "the truth" do
-    assert 1 + 1 == 2
-  end
-end


### PR DESCRIPTION
The service callback is expected to expose the following API:

  @type action_id :: string
  @type action_description :: string
  @type action_run_result :: {:ok, string} | {:error, string}
  @type action :: {action_id, action_description}

  @spec actions() :: [action]

  @spec run_action(action) :: action_run_result

@arkgil review would be useful.